### PR TITLE
Fix file name so long

### DIFF
--- a/plugins/dl_button.py
+++ b/plugins/dl_button.py
@@ -53,7 +53,7 @@ async def ddl_call_back(bot, update):
         if youtube_dl_url is not None:
             youtube_dl_url = youtube_dl_url.strip()
         if custom_file_name is not None:
-            custom_file_name = custom_file_name.strip()
+            custom_file_name = custom_file_name.strip()[:50]
         # https://stackoverflow.com/a/761825/4723940
         logger.info(youtube_dl_url)
         logger.info(custom_file_name)

--- a/plugins/dl_button.py
+++ b/plugins/dl_button.py
@@ -53,7 +53,7 @@ async def ddl_call_back(bot, update):
         if youtube_dl_url is not None:
             youtube_dl_url = youtube_dl_url.strip()
         if custom_file_name is not None:
-            custom_file_name = custom_file_name.strip()[:50]
+            custom_file_name = custom_file_name.strip()
         # https://stackoverflow.com/a/761825/4723940
         logger.info(youtube_dl_url)
         logger.info(custom_file_name)

--- a/plugins/youtube_dl_button.py
+++ b/plugins/youtube_dl_button.py
@@ -44,7 +44,7 @@ async def youtube_dl_call_back(bot, update):
         )
         return False
     youtube_dl_url = update.message.reply_to_message.text
-    custom_file_name = str(response_json.get("title")) + \
+    custom_file_name = str(response_json.get("title"))[:50] + \
         "_" + youtube_dl_format + "." + youtube_dl_ext
     youtube_dl_username = None
     youtube_dl_password = None
@@ -69,7 +69,7 @@ async def youtube_dl_call_back(bot, update):
         if youtube_dl_url is not None:
             youtube_dl_url = youtube_dl_url.strip()
         if custom_file_name is not None:
-            custom_file_name = custom_file_name.strip()[:50]
+            custom_file_name = custom_file_name.strip()
         # https://stackoverflow.com/a/761825/4723940
         if youtube_dl_username is not None:
             youtube_dl_username = youtube_dl_username.strip()

--- a/plugins/youtube_dl_button.py
+++ b/plugins/youtube_dl_button.py
@@ -69,7 +69,7 @@ async def youtube_dl_call_back(bot, update):
         if youtube_dl_url is not None:
             youtube_dl_url = youtube_dl_url.strip()
         if custom_file_name is not None:
-            custom_file_name = custom_file_name.strip()
+            custom_file_name = custom_file_name.strip()[:50]
         # https://stackoverflow.com/a/761825/4723940
         if youtube_dl_username is not None:
             youtube_dl_username = youtube_dl_username.strip()


### PR DESCRIPTION
Fix some problem with download from facebook and file name too long (text from facebook post is filename)
![IMG_20220320_152026](https://user-images.githubusercontent.com/5106227/159154121-e2774f9f-b69b-4f2d-8d65-1150ba58d438.jpg)
