### PR TITLE
Fix unicode in title

### DIFF
--- a/plugins/youtube_dl_button.py
+++ b/plugins/youtube_dl_button.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from config import Config
 # the Strings used for this "thing"
 from translation import Translation
+from transliterate import translit
 from plugins.custom_thumbnail import *
 logging.getLogger("pyrogram").setLevel(logging.WARNING)
 from pyrogram.types import InputMediaPhoto
@@ -99,7 +100,7 @@ async def youtube_dl_call_back(bot, update):
     tmp_directory_for_each_user = Config.DOWNLOAD_LOCATION + "/" + str(update.from_user.id)
     if not os.path.isdir(tmp_directory_for_each_user):
         os.makedirs(tmp_directory_for_each_user)
-    download_directory = tmp_directory_for_each_user + "/" + custom_file_name
+    download_directory = tmp_directory_for_each_user + "/" +  translit(custom_file_name, language_code='ru', reversed=True)
     command_to_exec = []
     if tg_send_type == "audio":
         command_to_exec = [


### PR DESCRIPTION
When downloading a video with a title containing Russian text, the script crashed.  I don't know how to check for the presence of unicode codes in the title and I still need to remove emoticons from the title.  Or use a random name for YouTube-dl so that there are no unicode codes at all